### PR TITLE
test.yaml: switch from arm64 to amd64

### DIFF
--- a/test.yaml
+++ b/test.yaml
@@ -1,7 +1,7 @@
 distribution:
         source: debian
         release: buster
-        architecture: arm64
+        architecture: amd64
 
 image:
         - name: test-image


### PR DESCRIPTION
Travis CI would not let us configure binfmt and therefore execute
foreign-arch binaries. Switch to amd64 image builds for our (limited)
CI builds.

Signed-off-by: Cedric Hombourger <chombourger@gmail.com>